### PR TITLE
[geojson] Allowing coordinates with more than 2 dimensions

### DIFF
--- a/geojson/geometry.json
+++ b/geojson/geometry.json
@@ -60,8 +60,7 @@
             "description": "A single position",
             "type": "array",
             "minItems": 2,
-            "items": [ { "type": "number" }, { "type": "number" } ],
-            "additionalItems": false
+            "items": { "type": "number" }
         },
         "positionArray": {
             "description": "An array of positions",


### PR DESCRIPTION
The geojson schema already had globally this possibility but a bug was remaining here.
