### PR TITLE
[geojson] Feature#id is a string or a number

### DIFF
--- a/geojson/geojson.json
+++ b/geojson/geojson.json
@@ -41,7 +41,7 @@
                     ]
                 },
                 "properties": { "type": [ "object", "null" ] },
-                "id": { "FIXME": "may be there, type not known (string? number?)" }
+                "id": {"type": [ "string", "number" ]}
             }
         },
         "featureCollection": {


### PR DESCRIPTION
According to the The GeoJSON Format IETF in-progress draft version 6 (2015-07-19) : https://www.ietf.org/id/draft-butler-geojson-06.txt ( https://datatracker.ietf.org/doc/draft-butler-geojson/ )

> If a feature has a commonly used identifier, that identifier
>       SHOULD be included as a member of the feature object with the name
>       "id" and the value of this member is either a JSON string or
>       number.
