### PR TITLE
JSON RPC 2.0 request schema: add minItems to batch

### DIFF
--- a/jsonrpc2.0/jsonrpc-request-2.0.json
+++ b/jsonrpc2.0/jsonrpc-request-2.0.json
@@ -9,6 +9,7 @@
         {
             "description": "An array of requests",
             "type": "array",
+            "minItems": 1,
             "items": { "$ref": "#/definitions/request" }
         }
     ],


### PR DESCRIPTION
From spec:

> If the batch rpc call itself fails to be recognized as an valid JSON or as an Array with at least one value, the response from the Server MUST be a single Response object.
> 
> ...
> 
> rpc call with an empty Array:
> 
> ```
> --> []
> <-- {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid Request"}, "id": null}
> ```
